### PR TITLE
Better sendFile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nim: ['1.4.2', 'stable', 'devel']
+        nim: ['1.6.0', 'stable', 'devel']
         gc:  ['refc', 'orc']
     name: Nim ${{ matrix.nim }} ${{ matrix.gc }}
     steps:

--- a/mike.nimble
+++ b/mike.nimble
@@ -15,6 +15,7 @@ skipFiles = @["benchmark.nim"]
 requires "nim >= 1.4.2"
 requires "httpx >= 0.3.0 & < 0.4.0"
 requires "websocketx >= 0.1.2"
+requires "zippy >= 0.10.3"
 
 task ex, "Runs the example":
     selfExec "c -f -d:debug -r example"

--- a/mike.nimble
+++ b/mike.nimble
@@ -12,7 +12,7 @@ skipFiles = @["benchmark.nim"]
 
 # Dependencies
 
-requires "nim >= 1.4.2"
+requires "nim >= 1.6.0"
 requires "httpx >= 0.3.0 & < 0.4.0"
 requires "websocketx >= 0.1.2"
 requires "zippy >= 0.10.3"

--- a/src/mike/context.nim
+++ b/src/mike/context.nim
@@ -38,7 +38,7 @@ proc newResponse*(): Response =
   ## Creates a new response
   result = Response(
     code: Http200,
-    headers: newHttpHeaders(),
+    headers: newHttpHeaders(titleCase=true),
     body: ""
   )
 

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -4,7 +4,8 @@ import std/[
   httpcore,
   json,
   asyncdispatch,
-  times
+  times,
+  strutils
 ]
 import ../context
 import ../response as res
@@ -94,7 +95,7 @@ proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders =
         ctx.setHeader("Content-Type", mimeDB.getMimeType(ext))
       # TODO: Stream the file
       # Check if the client allows us to compress the file
-      if ctx.getHeader("Accept-Encoding", "") == "gzip":
+      if "gzip" in ctx.getHeader("Accept-Encoding", ""):
         ctx.setHeader("Content-Encoding", "gzip")
         ctx.send(compress(filePath.readFile(), BestSpeed, dfGzip))
       else:

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -32,8 +32,10 @@ proc `&`(parent, child: HttpHeaders): HttpHeaders =
         for k, v in child:
             result[k] = v
 
+
 proc send*(ctx: Context, body: sink string, code: HttpCode, extraHeaders: HttpHeaders = nil) =
     ## Responds to a context and overwrites the status code
+    assert not ctx.handled, "Respons has already been sent"
     ctx.response.code = code
     ctx.response.body = body
     ctx.request.send(
@@ -152,7 +154,6 @@ proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders =
       close file
     else:
         # Check if the client allows us to compress the file
-        echo "Sending compressed"
         case getCompression(ctx.getHeader("Accept-Encoding", ""))
         of "gzip":
           ctx.sendCompressed(filePath.readFile(), dfGzip)
@@ -160,4 +161,4 @@ proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders =
           ctx.sendCompressed(filePath.readFile(), dfDeflate)
         else:
           ctx.send(filePath.readFile())
-
+    ctx.handled = true

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -32,7 +32,6 @@ proc `&`(parent, child: HttpHeaders): HttpHeaders =
 proc send*(ctx: Context, body: sink string, code: HttpCode, extraHeaders: HttpHeaders = nil) =
     ## Responds to a context and overwrites the status code
     ctx.response.code = code
-    ctx.response.headers["Content-Length"] = $body.len
     ctx.response.body = body
     ctx.request.send(
         body = ctx.response.body,

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -12,6 +12,7 @@ import ../errors
 import response
 import request
 import httpx
+import pkg/zippy
 ##
 ## Helpers for working with the context
 ##
@@ -92,5 +93,10 @@ proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders =
       {.gcsafe.}:
         ctx.setHeader("Content-Type", mimeDB.getMimeType(ext))
       # TODO: Stream the file
-      ctx.send(filePath.readFile())
+      # Check if the client allows us to compress the file
+      if ctx.getHeader("Accept-Encoding", "") == "gzip":
+        ctx.setHeader("Content-Encoding", "gzip")
+        ctx.send(compress(filePath.readFile(), BestSpeed, dfGzip))
+      else:
+        ctx.send(filePath.readFile())
 

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -113,10 +113,14 @@ proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders =
     if not filePath.fileExists:
         ctx.status = Http404
         raise (ref NotFoundError)(msg: filename & " cannot be found")
-        
-    if fpUserRead notin filePath.getFilePermissions():
+
+    # Check user can read the file and user isn't trying to escape to another folder'
+    if fpUserRead notin filePath.getFilePermissions() or not filePath.isRelativeTo(dir):
         ctx.status = Http403
         raise (ref UnauthorisedError)(msg: "You are unauthorised to access this file")
+
+    if filename != "":
+      ctx.setHeader("Content-Disposition", "attachment")
 
     let info = getFileInfo(filePath)
     if ctx.hasHeader("If-Modified-Since") and 

--- a/src/mike/response.nim
+++ b/src/mike/response.nim
@@ -1,6 +1,7 @@
 import httpcore
 import context
 import httpx
+import std/options
 
 proc toString*(headers: sink HttpHeaders): string =
   ## Converts HttpHeaders into their correct string representation
@@ -13,10 +14,11 @@ proc toString*(headers: sink HttpHeaders): string =
     result &= ": "
     result &= value
     
-proc respond*(req: Request, ctx: Context) =
-    req.send(
-        body = ctx.response.body,
-        code = ctx.response.code,
-        headers = ctx.response.headers.toString()
-    )
-
+proc respond*(req: Request, ctx: Context, contentLength = none(string)) =
+  ## Responds to a request by sending info back to the client
+  req.send(
+      body = ctx.response.body,
+      code = ctx.response.code,
+      contentLength = contentLength,
+      headers = ctx.response.headers.toString()
+  )

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -47,7 +47,7 @@ test "Getting file that has been modified since":
 test "Getting file that hasn't been modified since":
   let info = getFileInfo("readme.md")
   let resp = get("/", {
-    "If-Modified-Since": format(info.lastWriteTime + 1.minutes, lastModifiedFormat, utc())
+    "If-Modified-Since": format(info.lastWriteTime, lastModifiedFormat, utc())
   })
   check:
     resp.code == Http304

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -54,7 +54,7 @@ test "Getting file that hasn't been modified since":
 
 test "Server compresses when client allows":
   let resp = get("/", {
-    "Accept-Encoding": "gzip"
+    "Accept-Encoding": "gzip, deflate"
   })
   check:
     resp.headers["Content-Encoding"] == "gzip"

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -4,6 +4,7 @@ import utils
 import unittest
 import times
 import os
+import osproc
 
 import pkg/zippy
 
@@ -59,6 +60,12 @@ test "Server compresses when client allows":
   check:
     resp.headers["Content-Encoding"] == "gzip"
     resp.body.uncompress() == readmeFile
+
+test "Check against curl":
+  let (body, exitCode) = execCmdEx("curl -s --compressed http://127.0.0.1:8080/")
+  check:
+    exitCode == 0
+    body == readmeFile
 
 when false:
    test "Can't read forbidden file":

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -7,7 +7,9 @@ import os
 
 import pkg/zippy
 
-from mike/helpers/context {.all.} import lastModifiedFormat
+# from mike/helpers/context {.all.} import lastModifiedFormat
+# Since {.all.} isn't on 1.4 I need to do this
+const lastModifiedFormat = "ddd',' dd MMM yyyy HH:mm:ss 'GMT'"
 
 "/" -> get:
     await ctx.sendFile "readme.md"

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -19,10 +19,16 @@ from mike/helpers/context {.all.} import lastModifiedFormat
 "/forbidden" -> get:
     await ctx.sendFile "tests/forbidden.txt"
 
+"/testFile" -> get:
+    let file = ctx.getHeader("filePath")
+    await ctx.sendFile(file, dir = "tests/")
+
 
 runServerInBackground()
 
-let readmeFile = readFile("readme.md")
+let
+  readmeFile = readFile("readme.md")
+  thisFile = readFile("tests/testFileSending.nim")
 
 test "File is sent":
     check get("/").body == readmeFile
@@ -32,6 +38,13 @@ test "Trying to access non existant file":
 
 test "Trying to access non existant again":
     check get("/filedoesntexist").code == Http404
+
+suite "Files inside different directory":
+  test "Trying to access file at base directory":
+    check get("/testFile", {"filePath": "testFileSending.nim"}).body == thisFile
+
+  test "Trying to access file outside of base directory":
+    check get("/testFile", {"filePath": "../.gitignore"}).code == Http403
 
 test "Getting file that has been modified since":
   let info = getFileInfo("readme.md")

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -8,9 +8,7 @@ import osproc
 
 import pkg/zippy
 
-# from mike/helpers/context {.all.} import lastModifiedFormat
-# Since {.all.} isn't on 1.4 I need to do this
-const lastModifiedFormat = "ddd',' dd MMM yyyy HH:mm:ss 'GMT'"
+from mike/helpers/context {.all.} import lastModifiedFormat
 
 "/" -> get:
     await ctx.sendFile "readme.md"

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -6,8 +6,8 @@ import std/exitprocs
 
 let client = newHttpClient()
 
-proc get*(url: string): httpclient.Response =
-    client.request("http://127.0.0.1:8080" & url)
+proc get*(url: string, headers: openArray[(string, string)] = []): httpclient.Response =
+    client.request("http://127.0.0.1:8080" & url, headers = newHttpHeaders(headers))
 
 proc post*(url: string, body: string): httpclient.Response =
     client.request("http://127.0.0.1:8080" & url, httpMethod = HttpPost, body = body)

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -4,7 +4,10 @@ import os
 import mike
 import std/exitprocs
 
-let client = newHttpClient()
+when not defined(useProxy):
+  let client = newHttpClient()
+else:
+  let client = newHttpClient(proxy = newProxy("http://127.0.0.1:8000"))
 
 proc get*(url: string, headers: openArray[(string, string)] = []): httpclient.Response =
     client.request("http://127.0.0.1:8080" & url, headers = newHttpHeaders(headers))


### PR DESCRIPTION
Files can now be compressed (uses zippy). This supports deflate and gzip compression methods.

Large files are also now stream, large files cannot be compressed though.

Also supports caching with the `If-Modified-Since` header