### PR TITLE
Move to custom data system instead of custom context

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,20 +14,3 @@ The 1.x does not mean it is production ready, it just means it is incompatible w
 "/mike" -> post:
     ctx.send("The worst framework around", Http427)
 ```
-
-
-### Context
-You can define a context to keep data between middlewares
-
-```nim
-type
-    Person = object of Context
-        name: string
-        
-"/home/:name" -> beforeGet(ctx: Person):
-    # You could fetch the user from the database or something
-    ctx.name = ctx.pathParams["name"]
-    
-"/home/:name" -> get(ctx: Person):
-    ctx.send ctx.name # Returns the name that was set before
-```

--- a/src/mike/context.nim
+++ b/src/mike/context.nim
@@ -3,7 +3,8 @@ import std/[
   with,
   strtabs,
   httpcore,
-  asyncdispatch
+  asyncdispatch,
+  options
 ]
 
 type
@@ -29,10 +30,91 @@ type
     request*: Request
     pathParams*: StringTableRef
     queryParams*: StringTableRef
+    data: seq[RootRef]
 
-  SubContext* = concept x
-    ## Refers to anything that inheriets Context_
-    x is Context
+proc hasData*[T: RootRef](ctx: Context, data: typedesc[T]): bool =
+  ## Returns true if `T` is in the context
+  runnableExamples:
+    type
+      Auth = ref object of RootObj
+      JWT = ref object of Auth
+
+    var ctx = Context()
+    ctx.setData(Auth())
+    # It has auth but we never set a JWT so it doesn't have that
+    assert ctx.hasData(Auth)
+    assert not ctx.hasData(JWT)
+  #==#
+  for d in ctx.data:
+    if d of T:
+      return true
+
+proc setData*[T: RootRef](ctx: Context, data: T) =
+  ## Adds `data` into the context. It must be unique i.e. `setData` cannot be called with two instances of `T`
+  assert not ctx.hasData(T), $T & " has already been set for the context"
+  ctx.data &= data
+
+proc replaceData*[T: RootRef](ctx: Context, data: T) =
+  ## Replaces `data` in context if its found. Adds normally if not found
+  var found = false
+  for d in ctx.data.mitems:
+    if d of T:
+      d = data
+      found = true
+  if not found:
+    ctx.data &= data
+
+proc getData*[T: RootRef](ctx: Context, _: typedesc[T]): T =
+  ## Gets the value of custom data stored in a context
+  runnableExamples:
+    import mike
+    type
+      Account = ref object of RootObj
+        balance: int
+        id: string
+
+    "/^path" -> beforeGet:
+      if ctx.hasHeader("accountID"):
+        # Just create default account. This could instead be loaded
+        # from the database
+        ctx.setData(Account(
+          balance: 9,
+          id: ctx.getHeader("accountID")
+        ))
+
+    "/account" -> get:
+      let data = ctx.getData(Account)
+      if data != nil:
+        ctx.send "Hello " & data.id
+      else:
+        ctx.send(Http404)
+  #==#
+  for d in ctx.data:
+    if d of T:
+      return T(d)
+
+proc getData*[T: Option[ref object]](ctx: Context, _: typedesc[T]): T =
+  ## Gets the value of custom data stored in a context. If the data
+  ## cannot be found then `none(T)` is returned
+  runnableExamples:
+    import mike
+    type
+      Account = ref object of RootObj
+        balance: int
+        id: string
+
+    # There are no before handlers to add the data so it
+    # will always return none
+    "/account" -> get:
+      let p = ctx.getData(Option[Account])
+      if p.isNone:
+        ctx.send "This account isn't here"
+      else:
+        ctx.send "Hello " & p.get().id
+  #==#
+  let d = ctx.getData(T.T)
+  if d != nil:
+    result = some d
 
 proc newResponse*(): Response =
   ## Creates a new response

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -69,6 +69,14 @@ proc send*(ctx: Context, body: sink string, extraHeaders: HttpHeaders = nil) =
         extraHeaders = extraHeaders
     )
 
+proc send*(ctx: Context, code: HttpCode, extraHeaders: HttpHeaders = nil) =
+  ## Responds with just a status code
+  ctx.send(
+    "",
+    code,
+    extraHeaders = extraHeaders
+  )
+
 const
   maxReadAllBytes {.intdefine.} = 10_000_000
     ## Max size in bytes before buffer reading

--- a/src/mike/macroutils.nim
+++ b/src/mike/macroutils.nim
@@ -39,7 +39,7 @@ proc getHandlerInfo*(path: string, info, body: NimNode): HandlerInfo =
   ## Gets info about a handler.
   result.path = path
   # Run assert, though it shouldn't be triggered ever since we check this before
-  if info.kind notin {nnkIdent, nnkObjConstr}:
+  if info.kind notin {nnkIdent, nnkObjConstr, nnkCall}:
     "You have specified a route incorrectly. It should be like `get(<parameters>):` or `get:`".error(info)
   var verbIdent: NimNode
   if info.kind == nnkIdent:
@@ -90,28 +90,6 @@ func getHandlerBody(handler: NimNode): NimNode =
         #     # body
         handler.body()
 
-## These next few procs are from beef's oopsie library (https://github.com/beef331/oopsie)
-## Great library except I needed the code to work on NimNode directly
-
-proc getRefTypeImpl(obj: NimNode): NimNode = obj.getTypeImpl[0].getTypeImpl()
-
-proc superImpl(obj: NimNode): NimNode =
-    let impl = obj.getRefTypeImpl
-    assert impl[1].kind == nnkOfInherit
-    impl[1][0]
-
-proc super*(obj: NimNode): NimNode =
-    var obj = obj.getTypeImpl[1].getTypeImpl() # Get the type that is in a typedesc
-    if obj.typeKind == ntyRef:
-        if not obj.getRefTypeImpl[1][0].eqIdent("RootObj"):
-            var sup = obj
-            while not sup.getRefTypeImpl[1][0].eqIdent("RootObj"):
-                sup = sup.superImpl
-            result = sup
-        else: result = obj
-    else:
-        result = obj
-
 proc newHookCall(hookname: string, ctxIdent, kind: NimNode, name: string): NimNode =
     result =
         nnkLetSection.newTree(
@@ -149,14 +127,12 @@ proc createAsyncHandler*(handler: NimNode,
     )
     var
         ctxIdent = ident "ctx"
-        ctxType  = ident "Context"
         hookCalls = newStmtList()
     # Find the context first if it exists
     for parameter in parameters:
-        if parameter.kind.super().eqIdent(ctxType):
-            ctxIdent = ident parameter.name
-            ctxType  = parameter.kind
-            break
+      if parameter.kind.eqIdent("Context"):
+        ctxIdent = ident parameter.name
+        break
     # Then add all the calls which require the context
     for parameter in parameters:
         if not parameter.name.eqIdent(ctxIdent):
@@ -175,10 +151,6 @@ proc createAsyncHandler*(handler: NimNode,
             ident "gcsafe"
         )
     )
-
-    if not ctxType.eqIdent("Context"):
-      # This is needed for nim 1.6+
-      result.body.insert(0, newLetStmt(ctxIdent, newCall(ctxType, ctxIdent)))
 
 proc createParamPairs*(handler: NimNode): seq[NimNode] =
     ## Converts the parameters in `handler` into a sequence of name, type, name, type, name, type...

--- a/src/mike/router.nim
+++ b/src/mike/router.nim
@@ -10,9 +10,7 @@ import std/[
     algorithm
 ]
 
-import std/uri except decodeQuery
 
-import context
 import common
 import httpx
 
@@ -22,7 +20,6 @@ type
 
   RoutingResult*[T] = object
     pathParams*: StringTableRef
-    queryParams*: StringTableRef
     status*: bool
     handler*: T
 
@@ -118,12 +115,7 @@ func `$`*(nodes: seq[PatternNode]): string =
     of Greedy:
       result &= "^" & node.val
 
-func getPathAndQuery*(url: sink string): tuple[path, query: string] {.inline.} =
-    ## Returns the path and query string from a url
-    let pathLength = url.parseUntil(result.path, '?')
-    # Add query string that comes after
-    if pathLength != url.len():
-        result.query = url[pathLength + 1 .. ^1]
+
 
 func checkPathCharacters*(path: string): (bool, char) =
     ## Returns false if there are any illegal characters
@@ -240,23 +232,15 @@ proc rearrange*[T](router: var Router[T]) {.raises: [].} =
   for verb in router.verbs.mitems:
     verb.sort(cmp)
 
-proc extractEncodedParams(input: sink string, table: var StringTableRef) {.inline.} =
-  ## Extracts the parameters into a table
-  for (key, value) in input.decodeQuery():
-    table[key] = value
 
 # TODO: Should be iterator but breaks with orc for some reason?
 proc route*[T](router: Router[T], verb: HttpMethod, url: sink string): seq[RoutingResult[T]] {.raises: [].}=
   # Keep track of if we have found the main handler
   var foundMain = false
-  let (path, query) = url.getPathAndQuery()
-  var queryParams = newStringTable()
-  extractEncodedParams(query, queryParams)
   for handler in router.verbs[verb]:
-    var res = handler.match(path)
+    var res = handler.match(url)
     # Only pass main handlers once
     if res.status and (not foundMain or handler.pos != Middle):
-      res.queryParams = queryParams
       foundMain = foundMain or handler.pos == Middle
       result &= res
 

--- a/src/mike/router.nim
+++ b/src/mike/router.nim
@@ -260,12 +260,3 @@ proc route*[T](router: Router[T], verb: HttpMethod, url: sink string): seq[Routi
       foundMain = foundMain or handler.pos == Middle
       result &= res
 
-
-
-
-# proc route*(router: Router[Handler], ctx: Context): RoutingResult[Handler] =
-    # result = router.route(
-        # ctx.request.httpMethod.get(),
-        # ctx.request.path.get()
-    # )
-        

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -13,11 +13,11 @@ import std/[
 
 
 
-type PersonCtx* = ref object of Context
+type
+  Person* = ref object of RootObj
     name*: string
 
-
-type Frog = object
+  Frog = object
     colour: string
 
 #
@@ -51,27 +51,29 @@ servePublic("tests/public", "static", {
 "/uppercase" -> post:
     return ctx.request.body.get().toUpperAscii()
 
-"/person/:name" -> beforeGet(ctx: PersonCtx):
-    ctx.name = ctx.pathParams["name"]
+"/person/:name" -> beforeGet():
+    ctx.setData(Person(name: ctx.pathParams["name"]))
 
-"/person/:name" -> get(ctx: PersonCtx):
-    return "Hello, " & ctx.name
+"/person/:name" -> get():
+    return "Hello, " & ctx.getData(Person).name
 
-"/another" -> beforeGet(ctx: PersonCtx):
-  ctx.name = "human"
+"/another" -> beforeGet():
+  ctx.setData(Person(name: "human"))
   ctx.response.body = "another "
 
 "/another" -> get:
     ctx.response.body &= "one"
 
-"/another" -> afterGet(ctx: PersonCtx):
-  assert ctx.name == "human"
+"/another" -> afterGet():
+  assert ctx.getData(Person).name == "human"
 
-"/upper/:name" ->  beforeGet(ctx: PersonCtx):
-    ctx.name = ctx.pathParams["name"].toUpperAscii()
+"/upper/:name" ->  beforeGet():
+    ctx.setData(Person())
+    var person = ctx.getData(Person)
+    person.name = ctx.pathParams["name"].toUpperAscii()
 
-"/upper/:name" -> get(ctx: PersonCtx):
-    return "Good evening, " & ctx.name
+"/upper/:name" -> get():
+    return "Good evening, " & ctx.getData(Person).name
 
 "/helper/json" -> get:
     ctx.json = Frog(colour: "green")


### PR DESCRIPTION
Custom context worked pretty terribly and made the code more complex. This moves it to a custom data system instead where you can add data to a context like `ctx &= someObject` and get it back later with `ctx[SomeObject]`. 

Allows for handlers to pass along more complex data and gains speed that was lost when the custom context system was implemented