### PR TITLE
Files support HEAD and range requests

### DIFF
--- a/mike.nimble
+++ b/mike.nimble
@@ -13,7 +13,7 @@ skipFiles = @["benchmark.nim"]
 # Dependencies
 requires "nim >= 1.6.0"
 requires "zippy >= 0.10.3"
-requires "httpx >= 0.3.2"
+requires "httpx#6f03b2d"
 
 task ex, "Runs the example":
     selfExec "c -f -d:debug -r example"

--- a/mike.nimble
+++ b/mike.nimble
@@ -13,7 +13,7 @@ skipFiles = @["benchmark.nim"]
 # Dependencies
 requires "nim >= 1.6.0"
 requires "zippy >= 0.10.3"
-requires "httpx#6f03b2d"
+requires "httpx#92d0425"
 
 task ex, "Runs the example":
     selfExec "c -f -d:debug -r example"

--- a/src/mike/dsl.nim
+++ b/src/mike/dsl.nim
@@ -114,6 +114,10 @@ proc extractEncodedParams(input: sink string, table: var StringTableRef) {.inlin
   for (key, value) in common.decodeQuery(input):
     table[key] = value
 
+func noAsyncMsg(input: sink string): string {.inline.} =
+  ## Removes the async traceback from a message
+  debugEcho "Removing async traceback"
+  discard input.parseUntil(result, "Async traceback:")
 
 proc onRequest(req: Request): Future[void] {.async.} =
   {.gcsafe.}:
@@ -144,7 +148,7 @@ proc onRequest(req: Request): Future[void] {.async.} =
                        else: Http400
             ctx.send(ProblemResponse(
               kind: $fut.error[].name,
-              detail: fut.error[].msg,
+              detail: fut.error[].msg.noAsyncMsg(),
               status: code
             ))
             # We shouldn't continue after errors so stop processing

--- a/src/mike/errors.nim
+++ b/src/mike/errors.nim
@@ -52,6 +52,7 @@ makeErrorConstructor(BadRequest, Http400)
 makeErrorConstructor(UnAuthorised, Http401)
 makeErrorConstructor(Forbidden, Http403)
 makeErrorConstructor(NotFound, Http404)
+makeErrorConstructor(RangeNotSatisfiable, Http416)
 makeErrorConstructor(InternalServer, Http500)
 
 export httpcore

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -246,6 +246,7 @@ proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders =
       # if streaming the file
       ctx.response.body.setLen(0)
       ctx.request.respond(ctx, some info.size.int)
+      ctx.handled = true
       # Start streaming the file
       if ctx.httpMethod == HttpHead:
         return

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -39,7 +39,7 @@ proc send*(ctx: Context, body: sink string, code: HttpCode, extraHeaders: HttpHe
         body = if ctx.httpMethod notin {HttpHead, HttpOptions}: body else: "",
         code = ctx.response.code,
         headers = (ctx.response.headers & extraHeaders).toString(),
-        contentLength = some (if ctx.httpMethod != HttpOptions: $body.len else: $0) # Why does HTTPX have it as a string?
+        contentLength = some (if ctx.httpMethod != HttpOptions: $body.len else: $0)  # Why does HTTPX have it as a string?
     )
     ctx.handled = true
 

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -237,7 +237,6 @@ proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders =
           let readSize = min((size - read), bufsize)
           read += readSize
           ctx.request.unsafeSend(await file.read(readSize))
-        echo "Done"
         return
     # If not doing range request then check if we need to stream file or not.
     # We want to not stream for small files so that we can compress them.

--- a/src/mike/public.nim
+++ b/src/mike/public.nim
@@ -68,7 +68,8 @@ macro servePublic*(folder, path: static[string], renames: openarray[(string, str
       when not staticFiles:
         await ctx.sendFile(
           path,
-          folder
+          folder,
+          allowRanges = true
         )
       else:
         {.gcsafe.}:

--- a/src/mike/public.nim
+++ b/src/mike/public.nim
@@ -60,7 +60,7 @@ macro servePublic*(folder, path: static[string], renames: openarray[(string, str
       # get the time when run and use that for caching
       let startTime = now().utc
 
-    fullPath -> get:
+    fullPath -> [get, head]:
       let origPath = ctx.pathParams["file"]
       {.gcsafe.}:
         let path = if origPath in renameTable: renameTable[origPath]

--- a/src/mike/response.nim
+++ b/src/mike/response.nim
@@ -14,7 +14,7 @@ proc toString*(headers: sink HttpHeaders): string =
     result &= ": "
     result &= value
     
-proc respond*(req: Request, ctx: Context, contentLength = none(string)) =
+proc respond*(req: Request, ctx: Context, contentLength = none(int)) =
   ## Responds to a request by sending info back to the client
   req.send(
       body = ctx.response.body,

--- a/src/mike/response.nim
+++ b/src/mike/response.nim
@@ -5,14 +5,10 @@ import std/options
 
 proc toString*(headers: sink HttpHeaders): string =
   ## Converts HttpHeaders into their correct string representation
-  var first = true
-  for key, value in headers.pairs():
-    if not first:
-      result &= "\c\L"
-    first = false
-    result &= key
-    result &= ": "
-    result &= value
+  if headers.len > 0:
+    for key, value in headers.pairs():
+      result &= key & ": " & value & "\c\L"
+    result.setLen(result.len - 2)
     
 proc respond*(req: Request, ctx: Context, contentLength = none(int)) =
   ## Responds to a request by sending info back to the client

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -12,16 +12,16 @@ import pkg/zippy
 
 from mike/helpers/context {.all.} import lastModifiedFormat, maxReadAllBytes
 
-"/" -> get:
+"/" -> [get, head]:
   await ctx.sendFile "readme.md"
 
-"/filedoesntexist" -> get:
+"/filedoesntexist" -> [get, head]:
     await ctx.sendFile "notafile.html"
 
-"/forbidden" -> get:
+"/forbidden" -> [get, head]:
     await ctx.sendFile "tests/forbidden.txt"
 
-"/testFile" -> get:
+"/testFile" -> [get, head]:
     let file = ctx.getHeader("filePath")
     await ctx.sendFile(file, dir = "tests/")
 
@@ -126,7 +126,9 @@ suite "Compression":
       }
       getResp = get("/", headers)
       headResp = head("/", headers)
-    check getResp.headers == headResp.headers
+    check:
+      headResp.code == Http200
+      getResp.headers == headResp.headers
 
 test "Check against curl":
   let (body, exitCode) = execCmdEx("curl -s --compressed http://127.0.0.1:8080/")

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -218,13 +218,14 @@ suite "Helpers":
     check get("/redirect").body == "index"
 
   test "Send file":
-    let resp = get("http://127.0.0.1:8080/file?file=mike.nimble")
+    let resp = get("/file?file=mike.nimble")
     check resp.body == "mike.nimble".readFile()
     check resp.headers["Content-Type"] == "text/nimble"
     check resp.headers["Cache-Control"] == "public, max-age=432000"
 
-  test "Send file with HEAD request"
-    let resp = header("http://127.0.0.1:8080/file?file=mike.nimble")
+  test "Send file with HEAD request":
+    let resp = head("/file?file=mike.nimble")
+    check resp.code == Http200
     check resp.body == ""
     check resp.headers["Content-Type"] == "text/nimble"
     check resp.headers["Cache-Control"] == "public, max-age=432000"
@@ -278,7 +279,7 @@ suite "Public files":
     check get("/static/").headers["Content-Type"] == "text/html"
 
   test "Works with HEAD":
-    check head("/static/").headers == get("/static/")
+    check head("/static/").headers == get("/static/").headers
 
 suite "Multi handlers":
   const availableMethods = fullSet(HttpMethod) - {HttpConnect, HttpTrace}

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -107,7 +107,7 @@ servePublic("tests/public", "static", {
 
 "/file" -> [get, head]:
   ctx.setHeader("Cache-Control", "public, max-age=432000")
-  await ctx.sendFile(ctx.queryParams["file"])
+  await ctx.sendFile(ctx.queryParams["file"], useRanges=true)
 
 "/keyerror" -> get:
   raise (ref KeyError)(msg: "Should be overridden")
@@ -230,6 +230,10 @@ suite "Helpers":
     check resp.headers["Content-Type"] == "text/nimble"
     check resp.headers["Cache-Control"] == "public, max-age=432000"
 
+  test "Range request header set":
+    check head("/file?file=mike.nimble").headers["Range"] == "bytes"
+
+
 suite "Forms":
   test "URL encoded form GET":
     check get("/form?hello=world&john=doe").body == "world"
@@ -280,6 +284,10 @@ suite "Public files":
 
   test "Works with HEAD":
     check head("/static/").headers == get("/static/").headers
+
+  test "Range request":
+
+
 
 suite "Multi handlers":
   const availableMethods = fullSet(HttpMethod) - {HttpConnect, HttpTrace}

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -107,7 +107,7 @@ servePublic("tests/public", "static", {
 
 "/file" -> [get, head]:
   ctx.setHeader("Cache-Control", "public, max-age=432000")
-  await ctx.sendFile(ctx.queryParams["file"], useRanges=true)
+  await ctx.sendFile(ctx.queryParams["file"], allowRanges = true)
 
 "/keyerror" -> get:
   raise (ref KeyError)(msg: "Should be overridden")
@@ -231,7 +231,7 @@ suite "Helpers":
     check resp.headers["Cache-Control"] == "public, max-age=432000"
 
   test "Range request header set":
-    check head("/file?file=mike.nimble").headers["Range"] == "bytes"
+    check head("/file?file=mike.nimble").headers["Accept-Ranges"] == "bytes"
 
 
 suite "Forms":

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -285,9 +285,6 @@ suite "Public files":
   test "Works with HEAD":
     check head("/static/").headers == get("/static/").headers
 
-  test "Range request":
-
-
 
 suite "Multi handlers":
   const availableMethods = fullSet(HttpMethod) - {HttpConnect, HttpTrace}

--- a/tests/testStaticFiles.nim
+++ b/tests/testStaticFiles.nim
@@ -24,5 +24,11 @@ suite "Static files":
 
   test "Content type is set":
     check get("/static/index.html").headers["Content-Type"] == "text/html"
+
+  test "HEAD only sends headers":
+    let
+      getResp = get("/static/test.html")
+      headResp = head("/static/test.html")
+    check getResp.headers == headResp.headers
   # Write back to future tests dont fail
   testFilePath.writeFile(testHtml)

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -13,6 +13,9 @@ const root* = "http://127.0.0.1:8080".parseUri()
 proc get*(url: string, headers: openArray[(string, string)] = []): httpclient.Response =
     client.request(root / url, headers = newHttpHeaders(headers))
 
+proc head*(url: string, headers: openArray[(string, string)] = []): httpclient.Response =
+    client.request(root / url, headers = newHttpHeaders(headers), httpMethod = HttpHead)
+
 proc post*(url: string, body: string): httpclient.Response =
     client.request(root / url, httpMethod = HttpPost, body = body)
 

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -33,7 +33,15 @@ template stress*(body: untyped) =
     for i in 0..1000:
         body
 
-        
+proc `==`*(a, b: HttpHeaders): bool =
+  result = true
+  for k in a.table.keys:
+    if a[k] != b[k]:
+      return false
+  for k in b.table.keys:
+    if a[k] != b[k]:
+      return false
+
 template runServerInBackground*() =
     ## Starts the server on a seperate thread
     bind spawn


### PR DESCRIPTION
public files and `send` related procs will not send body with HEAD but will keep `Content-Length` of what would've been sent.

- [x] `send` doesn't send body if request was HEAD
- [x] Try not to read file if HEAD request is sent
- [x] Support [range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests)