### PR TITLE
Allow aliasing parameters for better reusability

### DIFF
--- a/src/mike/ctxhooks.nim
+++ b/src/mike/ctxhooks.nim
@@ -71,6 +71,14 @@ runnableExamples:
   "/people" -> get(auth {.name: "Authorization".}: Header[string]):
     echo auth
     ctx.send "Something"
+  # You can also use HookParam to save on typing if you use it in multiple places
+  type
+    AuthHeader = CtxParam["Authorization", Header[string]]
+      ## Get a string from a header named "Authorization"
+   
+  "/people" -> get(auth: AuthHeader):
+    echo auth
+    ctx.send "Something"
 
 ##[
   ### Form hooks
@@ -126,6 +134,10 @@ type
     ## Gets a cookie from the requst
     # This needs to reparse everytime, think parser is fast enough but not very optimal
     # Could maybe store cookies as custom data like a cache?.
+
+  CtxParam*[name: static[string], T] = distinct T
+    ## Used to alias a parameter for reusability.
+    ## `name` will be used instead of the normal parameter name
 
 #
 # Utils
@@ -306,4 +318,13 @@ proc fromRequest*[T: Option[BasicType]](ctx: Context, name: string, _: typedesc[
     var val: T.T
     val.parseCookie(cookies[name])
     result = some val
+    
+#
+# CtxParam
+#    
+
+proc fromRequest*[name: static[string], T](ctx: Context, n: string, 
+                                           _: typedesc[CtxParam[name, T]]): auto {.inline.} =
+  ctx.fromRequest(name, T)
+    
 export jsonutils

--- a/src/mike/ctxhooks.nim
+++ b/src/mike/ctxhooks.nim
@@ -76,7 +76,7 @@ runnableExamples:
     AuthHeader = CtxParam["Authorization", Header[string]]
       ## Get a string from a header named "Authorization"
    
-  "/people" -> get(auth: AuthHeader):
+  "/extraPeople" -> get(auth: AuthHeader):
     echo auth
     ctx.send "Something"
 

--- a/tests/testContextHooks.nim
+++ b/tests/testContextHooks.nim
@@ -110,6 +110,13 @@ type
     ctx.send $foo.get()
   else:
     ctx.send "Nothing"
+    
+type
+  AuthHeader = CtxParam["Authorization", Header[string]]
+
+"/ctxparam/1" -> get(auth: AuthHeader):
+  ctx.send auth
+
 
 runServerInBackground()
 
@@ -270,5 +277,10 @@ suite "Cookie":
 suite "Misc":
   test "Changing name of key":
     check get("/misc/1", {
+      "Authorization": "superSecretPassword"
+    }).body == "superSecretPassword"
+    
+  test "CtxParam can alias a parameter":
+    check get("/ctxparam/1", {
       "Authorization": "superSecretPassword"
     }).body == "superSecretPassword"


### PR DESCRIPTION
Can now use `CtxParam` to alias a name + type

e.g.
```nim
type
  AuthHeader = CtxParam["Authorization", Header[string]]
```

Now `AuthHeader` can be used and it will automatically use "Authorization" as the name

e.g.
```nim
# No need to do {.name: "Authorization".} since it already knows thats its name
"/secrets" -> get(auth: AuthHeader):
  # stuff
```