### PR TITLE
Fix issues with devel

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nim: ['1.6.0', 'stable', 'devel']
-        gc:  ['refc', 'orc']
+        nim: ['devel']
+        gc:  ['orc']
     name: Nim ${{ matrix.nim }} ${{ matrix.gc }}
     steps:
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        nim: ['devel']
-        gc:  ['orc']
+        nim: ['1.6.12', 'stable', 'devel']
+        gc:  ['refc', 'orc']
     name: Nim ${{ matrix.nim }} ${{ matrix.gc }}
     steps:
 

--- a/mike.nimble
+++ b/mike.nimble
@@ -13,7 +13,7 @@ skipFiles = @["benchmark.nim"]
 # Dependencies
 requires "nim >= 1.6.0"
 requires "zippy >= 0.10.3"
-requires "httpx#92d0425"
+requires "httpx#cce9afe"
 
 task ex, "Runs the example":
     selfExec "c -f -d:debug -r example"

--- a/mike.nimble
+++ b/mike.nimble
@@ -11,7 +11,7 @@ skipFiles = @["benchmark.nim"]
 
 
 # Dependencies
-requires "nim >= 1.6.0"
+requires "nim >= 1.6.12"
 requires "zippy >= 0.10.3"
 requires "httpx#cce9afe"
 

--- a/src/mike/cookies.nim
+++ b/src/mike/cookies.nim
@@ -65,14 +65,14 @@ proc `$`*(c: SetCookie): string {.raises: [].} =
   if c.httpOnly: result &= "; HttpOnly"
   result &= "; SameSite=" & $c.sameSite
 
-func initCookie*(name, value: string, domain, path = "", secure = true,
+func initCookie*(name, value: string, domain = "", path = "", secure = true,
                 httpOnly = false, sameSite = Lax): SetCookie  {.inline, raises: [].}=
   ## Creates a new session cookie, see [MDN Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-SetCookie) docs
   ## for explanation about the values
   result = SetCookie(name: name, value: value, domain: domain, path: path,
                      secure: secure, httpOnly: httpOnly, sameSite: sameSite)
 
-func initCookie*(name, value: string, maxAge: TimeInterval, domain, path = "", secure = true,
+func initCookie*(name, value: string, maxAge: TimeInterval, domain = "", path = "", secure = true,
                 httpOnly = false, sameSite = Lax): SetCookie {.inline, raises: [].} =
   ## Creates a new cookie that only lasts for a set amount of time
   ##
@@ -80,7 +80,7 @@ func initCookie*(name, value: string, maxAge: TimeInterval, domain, path = "", s
   result = initCookie(name, value, domain, path, secure, httpOnly, sameSite)
   result.maxAge = some maxAge
 
-func initCookie*(name, value: string, expires: DateTime, domain, path = "", secure = true,
+func initCookie*(name, value: string, expires: DateTime, domain = "", path = "", secure = true,
                 httpOnly = false, sameSite = Lax): SetCookie {.inline, raises: [].} =
   ## Creates a new cookie that only lasts until **expires**
   ##

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -241,7 +241,7 @@ proc closed*(ctx: Context): bool {.inline.} =
   result = ctx.request.closed
 
 proc sendFile*(ctx: Context, filename: string, dir = ".", headers: HttpHeaders = nil,
-               downloadName = "", charset = "utf-8", bufsize = 4096, allowRanges = false) {.gcsafe, async.} =
+               downloadName = "", charset = "utf-8", bufsize = 4096, allowRanges = false) {.async.} =
     ## Responds to a context with a file.
     ##
     ## * **allowRanges**: Whether to support [range requests](https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests). Only use

--- a/src/mike/helpers/context.nim
+++ b/src/mike/helpers/context.nim
@@ -152,9 +152,7 @@ proc beenModified*(ctx: Context, modDate: DateTime = now()): bool =
     # If the request doesn't have If-Modifie-Since
     # then we can assume our files are always newer
     return true
-  # Work around for bug in std/times
-  {.cast(gcsafe).}:
-    ctx.getHeader(header).parse(httpDateFormat, utc()) < zeroedDate
+  ctx.getHeader(header).parse(httpDateFormat, utc()) < zeroedDate
 
 proc setContentType*(ctx: Context, fileName: string) =
   ## Sets the content type to be for **fileName** e.g. `"index.html"` will set `"Content-Type"` header to `"text/html"`

--- a/src/mike/public.nim
+++ b/src/mike/public.nim
@@ -65,7 +65,7 @@ macro servePublic*(folder, path: static[string], renames: openarray[(string, str
         let path = if origPath in renameTable: renameTable[origPath]
                    else: origPath
       when not staticFiles:
-        await context.sendFile(ctx.
+        await context.sendFile(ctx,
           path,
           folder,
           allowRanges = true

--- a/src/mike/public.nim
+++ b/src/mike/public.nim
@@ -24,7 +24,7 @@ import errors
 
 let compiledAt = parse(CompileDate & " " & CompileTime, "yyyy-MM-dd HH:mm:ss")
 
-    
+
 macro servePublic*(folder, path: static[string], renames: openarray[(string, string)] = [],
                    staticFiles: static[bool] = defined(mikeStaticFiles)) =
   ## Serves files requested from **path**.
@@ -65,7 +65,7 @@ macro servePublic*(folder, path: static[string], renames: openarray[(string, str
         let path = if origPath in renameTable: renameTable[origPath]
                    else: origPath
       when not staticFiles:
-        await ctx.sendFile(
+        await context.sendFile(ctx.
           path,
           folder,
           allowRanges = true
@@ -73,11 +73,11 @@ macro servePublic*(folder, path: static[string], renames: openarray[(string, str
       else:
         {.gcsafe.}:
           if path in files:
-            if not ctx.beenModified(compiledAt):
+            if not context.beenModified(ctx, compiledAt):
               ctx.send("", Http304)
             else:
               ctx.setHeader("Last-Modified", compiledAt.format(httpDateFormat))
-              ctx.setContentType(path)
+              context.setContentType(ctx, path)
               ctx.sendCompressed(files[path])
           else:
             raise newNotFoundError(path & " not found")

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -176,7 +176,8 @@ suite "Compression":
       getResp = get("/", headers)
       headResp = head("/", headers)
     echo "========"
-    echo getResp.body.uncompress()
+    echo getResp.headers
+    echo get("/", headers).headers
     echo "========"
 
     check:

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -176,9 +176,7 @@ suite "Compression":
       getResp = get("/", headers)
       headResp = head("/", headers)
     echo "========"
-    echo headResp.body
-    echo "========"
-    echo getResp.body
+    echo getResp.body.uncompress()
     echo "========"
 
     check:

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -168,25 +168,6 @@ suite "Compression":
       resp.headers["Content-Encoding"] == "gzip"
       resp.body.uncompress(dfGzip) == readmeFile
 
-  test "Works with HEAD":
-    let
-      headers = {
-        "Accept-Encoding": "br;q=1.0, gzip;q=0.8, *;q=0.1"
-      }
-      getResp = get("/", headers)
-      headResp = head("/", headers)
-    echo "========"
-    sleep 1000
-    echo get("/", headers).headers
-    sleep 1000
-    echo head("/", headers).headers
-    echo "========"
-
-    check:
-      headResp.code == Http200
-      headResp.body.len == 0
-      getResp.headers == headResp.headers
-
 test "Check against curl":
   let (body, exitCode) = execCmdEx("curl -s --compressed http://127.0.0.1:8080/")
   check:

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -176,8 +176,10 @@ suite "Compression":
       getResp = get("/", headers)
       headResp = head("/", headers)
     echo "========"
-    echo getResp.headers
+    sleep 1000
     echo get("/", headers).headers
+    sleep 1000
+    echo head("/", headers).headers
     echo "========"
 
     check:

--- a/tests/testFileSending.nim
+++ b/tests/testFileSending.nim
@@ -175,8 +175,15 @@ suite "Compression":
       }
       getResp = get("/", headers)
       headResp = head("/", headers)
+    echo "========"
+    echo headResp.body
+    echo "========"
+    echo getResp.body
+    echo "========"
+
     check:
       headResp.code == Http200
+      headResp.body.len == 0
       getResp.headers == headResp.headers
 
 test "Check against curl":


### PR DESCRIPTION
Removes warnings and problems that occur when using devel.

~~The `gcsafe` cast is weird, seems to be a bug in Nim with forward declaring (Ran into it with another project but thought I was crazy). Will see if there is a proper fix~~ Issue was a regression in `std/times` where `initDateTime` was forward declared but not marked as `gcsafe`, waiting for PR to be merged

The test to check that HEAD and GET requests return the same was also removed since it failed due to zippy's  protection against BREACH attack