### PR TITLE
Make async pragma have same line number as handler

### DIFF
--- a/src/mike/macroutils.nim
+++ b/src/mike/macroutils.nim
@@ -131,7 +131,7 @@ proc getHandlerInfo*(path: string, info, body: NimNode): HandlerInfo =
     result.pos = pos
   else:
     ("Not a valid route verb `" & $toStrLit(verbIdent) & "`").error(verbIdent)
-  
+
 
 proc getPath*(handler: NimNode): string =
     ## Gets the path from a DSL adding call
@@ -158,7 +158,7 @@ proc createAsyncHandler*(handler: NimNode,
         if node.kind in {Param, Greedy} and node.val != "":
           params &= node.val
       params
-        
+
     let returnType = nnkBracketExpr.newTree(
         ident"Future",
         ident"string"
@@ -198,7 +198,10 @@ proc createAsyncHandler*(handler: NimNode,
                 let name = fromRequest(ctxIdent, paramName, paramKind)
             hookCalls &= hook
     hookCalls &= body
-    let name = genSym(nskProc, path)
+    let
+      name = genSym(nskProc, path)
+      asyncPragma = ident"async"
+    asyncPragma.copyLineInfo(handler)
     result = newStmtList(
       newProc(
         name = name,
@@ -208,7 +211,7 @@ proc createAsyncHandler*(handler: NimNode,
         ],
         body = hookCalls,
         pragmas = nnkPragma.newTree(
-            ident"async",
+            asyncPragma,
             ident"gcsafe"
         )
       ),


### PR DESCRIPTION
This makes `macroutils.nim` not show up in compile errors

**Example**
```nim
import mike

"/" -> get:
  unknownSymbol

run()
```

**Before**
```
foo.nim(3, 5) template/generic instantiation of `->` from here
nimbleDir/mike/macroutils.nim(211, 18) template/generic instantiation of `async` from here
foo.nim(4, 3) Error: undeclared identifier: 'unknownSymbol'
```

**After**
```
foo.nim(3, 5) template/generic instantiation of `->` from here
foo.nim(4, 3) Error: undeclared identifier: 'unknownSymbol'
```
