### PR TITLE
Uses methods for error handling

### DIFF
--- a/src/mike/dsl.nim
+++ b/src/mike/dsl.nim
@@ -81,6 +81,24 @@ macro `->`*(path: static[string], info: untyped, body: untyped): untyped =
     result = genAst(path = info.path, verbs = info.verbs, pos = info.pos, handlerProc):
         addHandler(path, verbs, pos, handlerProc)
 
+func noAsyncMsg(input: sink string): string {.inline.} =
+  ## Removes the async traceback from a message
+  discard input.parseUntil(result, "Async traceback:")
+
+method handleRequestError*(error: ref Exception, ctx: Context) {.base, async.} =
+  ## Base handler for handling errors. Use `<Exceptio> -> thrown`
+  ## instead of writing the method out yourself.
+  # If user has already provided an error status then use that
+  let code = if error[] of HttpError: HttpError(error[]).status
+             elif ctx.status.int in 400..599: ctx.status
+             else: Http400
+  # Send the details
+  ctx.send(ProblemResponse(
+    kind: $error[].name,
+    detail: error[].msg.noAsyncMsg(),
+    status: code
+  ), code)
+
 macro `->`*(error: typedesc[CatchableError], info, body: untyped) =
   ## Used to handle an exception. This is used to override the
   ## default handler which sends a [ProblemResponse](mike/errors.html#ProblemResponse)
@@ -90,6 +108,10 @@ macro `->`*(error: typedesc[CatchableError], info, body: untyped) =
     # If a key error is thrown anywhere then this will be called
     KeyError -> thrown:
       ctx.send("The key you provided is invalid")
+    # Method dispatch is used, so you can handle parent classes
+    # and have it run for all child classes
+    CatchableError -> thrown:
+      ctx.send("Some error was thrown")
   #==#
   if info.kind != nnkIdent and not info.eqIdent("thrown"):
     "Verb must be `thrown`".error(info)
@@ -97,12 +119,26 @@ macro `->`*(error: typedesc[CatchableError], info, body: untyped) =
     name = $error
     handlerProc = body.createAsyncHandler("/", @[])
 
-  result = nnkAsgn.newTree(
-    nnkBracketExpr.newTree(
-      bindSym"errorHandlers",
-      newLit name
+  result = nnkMethodDef.newTree(
+    ident"handleRequestError",
+    newEmptyNode(),
+    newEmptyNode(),
+    nnkFormalParams.newTree(
+      newEmptyNode(),
+      # Pass the error
+      nnkIdentDefs.newTree(
+        ident"error",
+        nnkRefTy.newTree(error),
+        newEmptyNode()
+      ),
+      # And also pass the context
+      newIdentDefs(ident"ctx", ident"Context")
     ),
-    handlerProc
+    nnkPragma.newTree(
+      ident"async"
+    ),
+    newEmptyNode(),
+    body
   )
 
 func getPathAndQuery(url: sink string): tuple[path, query: string] {.inline.} =
@@ -116,10 +152,6 @@ proc extractEncodedParams(input: sink string, table: var StringTableRef) {.inlin
   ## Extracts the parameters into a table
   for (key, value) in common.decodeQuery(input):
     table[key] = value
-
-func noAsyncMsg(input: sink string): string {.inline.} =
-  ## Removes the async traceback from a message
-  discard input.parseUntil(result, "Async traceback:")
 
 proc onRequest(req: Request): Future[void] {.async.} =
   {.gcsafe.}:
@@ -136,30 +168,14 @@ proc onRequest(req: Request): Future[void] {.async.} =
         var fut = routeResult.handler(ctx)
         yield fut
         if fut.failed:
-          errorHandlers.withValue(fut.error[].name, value):
-            discard await value[](ctx)
-          do:
-            # TODO: Provide catchall to allow overridding default handler?
-            #[
-              Exception -> thrown:
-                ctx.send "Default handler overrridden"
-            ]#
-            # If user has already provided an error status then use that
-            let code = if fut.error[] of HttpError: HttpError(fut.error[]).status
-                       elif ctx.status.int in 400..599: ctx.status
-                       else: Http400
             when defined(debug):
               stderr.styledWriteLine(
                   fgRed, "Error while handling: ", $req.httpMethod.get(), " ", req.path.get(),
                   "\n" ,fut.error[].msg, "\n", fut.error.getStackTrace(),
                   resetStyle
               )
-            ctx.handled = false
-            ctx.send(ProblemResponse(
-              kind: $fut.error[].name,
-              detail: fut.error[].msg.noAsyncMsg(),
-              status: code
-            ))
+            # ctx.handled = false
+            await handleRequestError(fut.error, ctx)
             # We shouldn't continue after errors so stop processing
             return
         else:

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -158,8 +158,14 @@ servePublic("tests/public", "static", {
 "/data/something/other" -> beforeGet:
   discard
 
+"/anyerror" -> get:
+  raise (ref ValueError)(msg: "This was thrown")
+
 KeyError -> thrown:
   ctx.send("That key doesn't exist")
+
+CatchableError -> thrown:
+  ctx.send("Some error was thrown")
 
 runServerInBackground()
 # run()
@@ -288,6 +294,10 @@ suite "Error handlers":
   test "Routes stop getting processed after an error":
     let resp  = get("/shoulderror")
     check resp.code == Http400
+
+  test "Parent can catch subclassed errors":
+    let resp = get("/anyerror")
+    check resp.body == "Some error was thrown"
 
 suite "Public files":
   const indexFile = readFile("tests/public/index.html")

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -118,8 +118,15 @@ servePublic("tests/public", "static", {
 "/shoulderror" -> beforeGet:
   raise (ref Exception)(msg: "Something failed")
 
-"shoulderror" -> get:
+"/shoulderror" -> get:
   ctx.send("This shouldn't send")
+
+type
+  ParentError = object of CatchableError
+  ChildError = object of ParentError
+
+"/anyerror" -> get:
+  raise (ref ChildError)(msg: "This was thrown")
 
 "/multi/1" -> [get, post]:
   discard
@@ -158,13 +165,10 @@ servePublic("tests/public", "static", {
 "/data/something/other" -> beforeGet:
   discard
 
-"/anyerror" -> get:
-  raise (ref ValueError)(msg: "This was thrown")
-
 KeyError -> thrown:
   ctx.send("That key doesn't exist")
 
-CatchableError -> thrown:
+ParentError -> thrown:
   ctx.send("Some error was thrown")
 
 runServerInBackground()


### PR DESCRIPTION
Finding a handler for an error is now done via methods instead of using a table. This means the lookup is cleaner than before (Two exceptions having the same name won't collide anymore) and also means it supports catching child exceptions 
```nim
type
  Parent = object of CatchableError
  Child = object of Parent

# If the child exception is thrown, it can be handled here
Parent -> thrown:
 # ... 
```

Performance is basically on par. Might actually be faster once Nim implements better dispatch for ORC (Think I saw a PR, don't know if it was merged)
