### PR TITLE
Support var types with hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ testagain.nim
 tests/*
 !tests/*.nim*
 # Ignore my test files I make in the root
-*.nim
+/*.nim
 .idea/

--- a/tests/testContextHooks.nim
+++ b/tests/testContextHooks.nim
@@ -126,6 +126,10 @@ type
 "/ctxparam/1" -> get(auth: AuthHeader):
   ctx.send auth
 
+"/varparam/1" -> get(head: var Header[string]):
+  head &= " foo"
+  ctx.send head
+
 runServerInBackground()
 
 proc errorMsg(x: httpclient.Response): string =
@@ -299,4 +303,7 @@ suite "Misc":
 
   test "Future procs have await called on them":
     check get("/misc/3").body == "hello"
+
+  test "Var params are allowed":
+    check get("/varparam/1", {"head": "hello"}).body == "hello foo"
 


### PR DESCRIPTION
Declares variables as `var` instead of `let` in the body of the handler if the parameter is `var T`

Closes #36 