### PR TITLE
Cleanup hook code

### DIFF
--- a/src/mike/ctxhooks.nim
+++ b/src/mike/ctxhooks.nim
@@ -75,7 +75,7 @@ runnableExamples:
   type
     AuthHeader = CtxParam["Authorization", Header[string]]
       ## Get a string from a header named "Authorization"
-   
+
   "/extraPeople" -> get(auth: AuthHeader):
     echo auth
     ctx.send "Something"
@@ -164,6 +164,10 @@ proc parseNum[T](param: string): T =
       raise newBadRequestError(fmt"Value '{param}' is out of range for {$T}")
   # Make it become the required number type
   cast[T](val)
+
+template fromRequest*(ctx: Context, name: string, _: typedesc[Context]): Context =
+  ## Enables renaming the context by marking a parameter as `Context`
+  ctx
 
 #
 # Path
@@ -318,13 +322,13 @@ proc fromRequest*[T: Option[BasicType]](ctx: Context, name: string, _: typedesc[
     var val: T.T
     val.parseCookie(cookies[name])
     result = some val
-    
+
 #
 # CtxParam
-#    
+#
 
-proc fromRequest*[name: static[string], T](ctx: Context, n: string, 
+proc fromRequest*[name: static[string], T](ctx: Context, n: string,
                                            _: typedesc[CtxParam[name, T]]): auto {.inline.} =
   ctx.fromRequest(name, T)
-    
+
 export jsonutils

--- a/tests/testContextHooks.nim
+++ b/tests/testContextHooks.nim
@@ -126,6 +126,14 @@ type
 "/ctxparam/1" -> get(auth: AuthHeader):
   ctx.send auth
 
+"/ctxrenamed" -> get(c: Context):
+  let ctx = "hello" # Make sure the variable can still be used
+  c.send "Renamed"
+
+"/reusename" -> get(x: Header[string]):
+  let x = x & "foo"
+  ctx.send x
+
 runServerInBackground()
 
 proc errorMsg(x: httpclient.Response): string =
@@ -300,3 +308,8 @@ suite "Misc":
   test "Future procs have await called on them":
     check get("/misc/3").body == "hello"
 
+  test "Context variable can be renamed":
+    check get("/ctxrenamed").body == "Renamed"
+
+  test "Parameter names can be reused":
+    check get("/reusename", {"x": "bar"}).body == "barfoo"


### PR DESCRIPTION
Fixes some issues I saw in previous PR. Namely
- ctx renaming can be done entirely with hooks, simplfies code and means its not special cased
- Parameters cannot have the name reused like they can be in normal procs