### PR TITLE
Default to non secure cookies

### DIFF
--- a/src/mike/cookies.nim
+++ b/src/mike/cookies.nim
@@ -65,14 +65,14 @@ proc `$`*(c: SetCookie): string {.raises: [].} =
   if c.httpOnly: result &= "; HttpOnly"
   result &= "; SameSite=" & $c.sameSite
 
-func initCookie*(name, value: string, domain = "", path = "", secure = true,
+func initCookie*(name, value: string, domain = "", path = "", secure = false,
                 httpOnly = false, sameSite = Lax): SetCookie  {.inline, raises: [].}=
   ## Creates a new session cookie, see [MDN Set-Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-SetCookie) docs
   ## for explanation about the values
   result = SetCookie(name: name, value: value, domain: domain, path: path,
                      secure: secure, httpOnly: httpOnly, sameSite: sameSite)
 
-func initCookie*(name, value: string, maxAge: TimeInterval, domain = "", path = "", secure = true,
+func initCookie*(name, value: string, maxAge: TimeInterval, domain = "", path = "", secure = false,
                 httpOnly = false, sameSite = Lax): SetCookie {.inline, raises: [].} =
   ## Creates a new cookie that only lasts for a set amount of time
   ##
@@ -80,7 +80,7 @@ func initCookie*(name, value: string, maxAge: TimeInterval, domain = "", path = 
   result = initCookie(name, value, domain, path, secure, httpOnly, sameSite)
   result.maxAge = some maxAge
 
-func initCookie*(name, value: string, expires: DateTime, domain = "", path = "", secure = true,
+func initCookie*(name, value: string, expires: DateTime, domain = "", path = "", secure = false,
                 httpOnly = false, sameSite = Lax): SetCookie {.inline, raises: [].} =
   ## Creates a new cookie that only lasts until **expires**
   ##

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -236,7 +236,7 @@ suite "Cookies":
 
   test "Cookies are escaped when getting sent":
     let resp = post("/cookies/return", "foo bar")
-    check resp.headers["Set-Cookie"] == "foo=foo+bar; Secure; SameSite=Lax"
+    check resp.headers["Set-Cookie"] == "foo=foo+bar; SameSite=Lax"
 
   test "Cookies are escaped when getting read":
     let resp = get("/cookies/return", headers={"Cookie": "foo=foo+bar"})

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -222,7 +222,7 @@ suite "Misc":
   test "Cookies are sent in response":
     let resp = get("/cookie")
     check resp.headers.hasKey("Set-Cookie")
-    check resp.headers["Set-Cookie"] == "foo=bar; Secure; SameSite=Lax"
+    check resp.headers["Set-Cookie"] == "foo=bar; SameSite=Lax"
 
 suite "Custom Data":
   test "Basic":


### PR DESCRIPTION
Safari has issues when it doesn't allow secure cookies on localhost (Like chrome and firefox does) which has caused issues in the past https://github.com/ire4ever1190/mike/issues/30#issuecomment-1929085574. Doing this so the behaviour is least surprising