### PR TITLE
Fix strtabs issue

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,14 +39,14 @@ jobs:
       run: nimble update && nimble build
 
     - name: Run Tests
-      run: nimble --gc:${{ matrix.gc }} test
+      run: nimble --mm:${{ matrix.gc }} test
 
     - name: Check example
       if: matrix.nim == 'devel'
-      run: nim c --warningAsError:UnusedImport:on --hintAsError:DuplicateModuleImport:on --gc:${{ matrix.gc }} example.nim
+      run: nim c --warningAsError:UnusedImport:on --hintAsError:DuplicateModuleImport:on --mm:${{ matrix.gc }} example.nim
 
     - name: Test doc examples
-      run: nimble --gc:${{ matrix.gc }} doc --warningAsError:BrokenLink:on --project src/mike.nim
+      run: nimble --mm:${{ matrix.gc }} doc --warningAsError:BrokenLink:on --project src/mike.nim
 
   deploy:
     needs: test

--- a/src/mike/public.nim
+++ b/src/mike/public.nim
@@ -48,7 +48,9 @@ macro servePublic*(folder, path: static[string], renames: openarray[(string, str
 
   # Now for the file sending code
   result = genAst(fullPath, folder, renames, staticFiles):
-    let renameTable = newStringTable(renames)
+    let
+      renameList = if renames.len > 0: @renames else: @[]
+      renameTable = newStringTable(renameList)
 
     # Build table of files if needed
     when staticFiles:

--- a/src/mike/public.nim
+++ b/src/mike/public.nim
@@ -49,6 +49,9 @@ macro servePublic*(folder, path: static[string], renames: openarray[(string, str
   # Now for the file sending code
   result = genAst(fullPath, folder, renames, staticFiles):
     let
+      # This is a strange hack to get around a codegen bug where the
+      # array isn't initialised
+      # TODO: Somehow minify the case and report the bug
       renameList = if renames.len > 0: @renames else: @[]
       renameTable = newStringTable(renameList)
 

--- a/tests/public/test.html
+++ b/tests/public/test.html
@@ -1,0 +1,1 @@
+<p>Hello world</p>

--- a/tests/public/test.html
+++ b/tests/public/test.html
@@ -1,1 +1,0 @@
-<p>Hello world</p>


### PR DESCRIPTION
Looking at this code (Where I removed irrelevant statements it seems the issue is with the macro not initialising anything
```c
tyOpenArray__WVNPwuOnFGyv6YyGQCJcew T1_;	tyObject_StringTableObj__G9bbVxRU175fg9b8kuOtTHAQ* T2_;
#line 51 FX_191
        // T1 is accessed here, but it hasn't been initialised
	T2_ = NIM_NIL;	T2_ = nstnewStringTableWithTableConstr(T1_.Field0, T1_.Field1, ((tyEnum_StringTableMode__INi19a0eFz0QzSJHG0kXv9bg)0));	if (NIM_UNLIKELY(*nimErr_)) {eqdestroy___pureZstrtabs_u524(T2_); goto BeforeRet_;}	renameTableX60gensym0___test83tatic70iles_u14 = T2_;
#line 56 FX_191
```
Which leads to a nil access error when running the public files test.

Currently my fix is a major hack (It depends on `T1_` being zero'd) but it atleast fixes the issue for now. Will need to track down why the compilers codegen is breaking