### PR TITLE
Minor update to dsl.nim

### DIFF
--- a/src/mike/dsl.nim
+++ b/src/mike/dsl.nim
@@ -162,7 +162,7 @@ proc onRequest(req: Request): Future[void] {.async.} =
         foundMain = false
       let
         ctx = req.newContext()
-        (path, query) = req.path.get().getPathAndQuery()
+        (path, query) = req.path.unsafeGet().getPathAndQuery()
       extractEncodedParams(query, ctx.queryParams)
       for routeResult in mikeRouter.route(req.httpMethod.unsafeGet(), path, foundMain):
         ctx.pathParams = routeResult.pathParams


### PR DESCRIPTION
Use `unsafeGet` since we already check that the path exists. There is still an assertion inside that we can probably remove since this is a hot path. This is just a minor edit that I saw in the github UI and was kinda curious if there is any performance gains