### PR TITLE
Make logging into a middleware

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Check example
         if: matrix.nim == 'devel'
-        run: nim c --warningAsError:UnusedImport:on --hintAsError:DuplicateModuleImport:on --mm:${{ matrix.gc }} example.nim
+        run: nim c --warningAsError:UnusedImport:on --hintAsError:DuplicateModuleImport:on --errorMax:0 --mm:${{ matrix.gc }} example.nim
 
       - name: Test doc examples
         run: nimble --mm:${{ matrix.gc }} doc --project src/mike.nim

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tests/*
 .idea/
 nimble.develop
 nimble.paths
+nimbledeps

--- a/mike.nimble
+++ b/mike.nimble
@@ -14,6 +14,7 @@ skipFiles = @["benchmark.nim"]
 requires "nim >= 2.2.4"
 requires "zippy >= 0.10.3"
 requires "httpx >= 0.3.8"
+requires "chronicles >= 0.12.0"
 
 task ex, "Runs the example":
     selfExec "c -f -d:debug -r example"

--- a/src/mike/app.nim
+++ b/src/mike/app.nim
@@ -210,7 +210,14 @@ macro wrapProc(path: static[string], x: proc): AsyncHandler =
   # Build a proc that just calls all the hooks and then calls the original proc
   result = newProc(
     params=[newEmptyNode(), newIdentDefs(ctxIdent, bindSym"Context")],
-    pragmas = nnkPragma.newTree(ident"async"),
+    pragmas = nnkPragma.newTree(
+      ident"async",
+      # Hide the wrapper from stacktraces, makes them cleaner
+      nnkExprColonExpr.newTree(
+        ident"stacktrace",
+        ident"off"
+      )
+    ),
     body = newStmtList(
       vars,
       body,

--- a/src/mike/app.nim
+++ b/src/mike/app.nim
@@ -1,7 +1,7 @@
 import router, context, common, errors, ctxhooks, dispatchTable, pragmas, macroutils
 import helpers
 
-import std/[httpcore, macros, options, asyncdispatch, parseutils, strtabs, terminal, cpuinfo, sugar, strutils]
+import std/[httpcore, macros, options, asyncdispatch, parseutils, strtabs, cpuinfo, sugar, strutils]
 
 import httpx
 

--- a/src/mike/helpers/request.nim
+++ b/src/mike/helpers/request.nim
@@ -4,7 +4,6 @@ import std/json
 import std/jsonutils
 import std/options
 import std/selectors
-import std/sugar
 import std/strformat
 import std/uri
 

--- a/src/mike/helpers/request.nim
+++ b/src/mike/helpers/request.nim
@@ -4,6 +4,8 @@ import std/json
 import std/jsonutils
 import std/options
 import std/selectors
+import std/sugar
+import std/strformat
 
 
 {.used.}
@@ -41,9 +43,19 @@ proc headers*(ctx: Context): HttpHeaders {.raises: [].} =
   except KeyError, IOSelectorsException:
     newHttpHeaders()
 
+proc tryHeader*(ctx: Context, key: string): Option[string] =
+  ## Attempts to get a header, returns `None` if it doesn't exist
+  ctx.request.headers.flatMap do (headers: HttpHeaders) -> Option[string]:
+    if headers.hasKey(key):
+      return some string(headers[key])
+
+
 proc getHeader*(ctx: Context, key: string): string =
-    ## Gets a header from the request with `key`
-    ctx.request.headers.get()[key]
+  ## Gets a header from the request with `key`
+  let header = ctx.tryHeader(key)
+  if header.isNone():
+    raise (ref KeyError)(msg: fmt"Header '{key}' is not in request")
+  return header.unsafeGet()
 
 proc getHeaders*(ctx: Context, key: string): seq[string] =
   ## Returns all values for a header. Use this if the request contains multiple
@@ -63,4 +75,3 @@ proc httpMethod*(ctx: Context): HttpMethod =
   ## Returns the HTTP method of a request
   # We already check it exists in the onrequest() so we can safely unsafely get it
   ctx.request.httpMethod.unsafeGet()
-

--- a/src/mike/helpers/request.nim
+++ b/src/mike/helpers/request.nim
@@ -6,6 +6,7 @@ import std/options
 import std/selectors
 import std/sugar
 import std/strformat
+import std/uri
 
 
 {.used.}
@@ -75,3 +76,7 @@ proc httpMethod*(ctx: Context): HttpMethod =
   ## Returns the HTTP method of a request
   # We already check it exists in the onrequest() so we can safely unsafely get it
   ctx.request.httpMethod.unsafeGet()
+
+proc url*(ctx: Context): Uri =
+  ## Returns the URL for a request
+  ctx.request.path.get().parseUri(result)

--- a/src/mike/middlewares/logging.nim
+++ b/src/mike/middlewares/logging.nim
@@ -1,0 +1,30 @@
+## This module contains middleware for configuring logging via [chronicles](https://github.com/status-im/nim-chronicles).
+##
+## In development, I recommend using the block sink via by compiling with `-d:chronicles_sinks=textblocks`. This makes the
+## exception messages more readable
+
+import ../[app, context]
+import ../helpers/request
+
+import std/[asyncdispatch, strformat, uri]
+
+import pkg/[httpx, chronicles]
+
+proc pathAndQuery(uri: sink Uri): string =
+  ## Returns the path and query combined
+  if uri.query != "":
+    return uri.path & "?" & uri.query
+  uri.path
+
+proc addLogging*(app: var App) =
+  ## Enables logging with the app.
+  ## All handlers passed will be registered on every spawned thread
+  # TODO: Use proper logfmt
+  app.beforeEach do (ctx: Context) {.async.}:
+    debug "Starting request", meth=ctx.httpMethod, path = $ctx.url
+
+  app.afterEach do (ctx: Context, err: ref Exception) {.async.}:
+    if err != nil:
+      error "Request failed", staus=ctx.response.code, error = $err.name, msg=err.msg, trace=err.getStackTrace()
+    else:
+      info "Request finished", meth=ctx.httpMethod, code=ctx.response.code, path = $ctx.url

--- a/src/mike/middlewares/logging.nim
+++ b/src/mike/middlewares/logging.nim
@@ -18,8 +18,6 @@ proc pathAndQuery(uri: sink Uri): string =
 
 proc addLogging*(app: var App) =
   ## Enables logging with the app.
-  ## All handlers passed will be registered on every spawned thread
-  # TODO: Use proper logfmt
   app.beforeEach do (ctx: Context) {.async.}:
     debug "Starting request", meth=ctx.httpMethod, path = $ctx.url
 


### PR DESCRIPTION
Stops doing the logging internally and is now implemented as a middleware to allow for multiple backends

Default implementation is chronicles since I found it to generate better logs than `std/logging`.

Noticed the wrapper proc was included in the stacktrace, removed it for now but might add it back later (ran into a bug when setting the name to be the path, think maybe Nim doesn't support it?)