### PR TITLE
breaking: Rename `Path` to `PathParam` to remove the collision with stdlib

### DIFF
--- a/src/mike/app.nim
+++ b/src/mike/app.nim
@@ -201,7 +201,7 @@ macro wrapProc(path: static[string], x: proc): AsyncHandler =
       var typ = identDef[^2]
       # Automatically mark variables that appear in the path as Path
       if $param in pathNames:
-        typ = nnkBracketExpr.newTree(bindSym"Path", typ)
+        typ = nnkBracketExpr.newTree(bindSym"PathParam", typ)
 
       # Remove `var` from types
       if typ.kind == nnkVarTy:

--- a/src/mike/ctxhooks.nim
+++ b/src/mike/ctxhooks.nim
@@ -372,7 +372,7 @@ type
   Data*[T: ref object | Option[ref object]] {.useCtxHook(getContextData).} = T
     ## Get the object from the contexts data
     # ref object is used over RootRef cause RootRef was causing problems
-  Path*[T: SomeNumber | string] {.useCtxHook(getPathValue).} = T
+  PathParam*[T: SomeNumber | string] {.useCtxHook(getPathValue).} = T
     ## Specifies that the parameter should be found in the path.
     ## This is automatically added to parameters that have the same name as a path parameter
   Form*[T] {.useCtxHook(formFromRequest).} = T

--- a/tests/testContextHooks.nim
+++ b/tests/testContextHooks.nim
@@ -15,7 +15,7 @@ import std/[
 "/person/:name" -> get(name: string):
   ctx.send name
 
-"/path/:name" -> get(name: Path[string]):
+"/path/:name" -> get(name: PathParam[string]):
   ctx.send name
 
 "/headers/1" -> get(something: Header[string]):


### PR DESCRIPTION
With the focus on types going forward, best to remove this collision so its easier to use the two. Most of the time you aren't writing out `Path` anyways so shouldn't break much