### PR TITLE
Add function for getting IP address

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -5,7 +5,6 @@ when defined(testing):
 switch("define", "chronicles_sinks=textblocks")
 
 # begin Nimble config (version 2)
---noNimblePath
 when withDir(thisDir(), system.fileExists("nimble.paths")):
   include "nimble.paths"
 # end Nimble config

--- a/mike.nimble
+++ b/mike.nimble
@@ -15,6 +15,7 @@ requires "nim >= 2.2.4"
 requires "zippy >= 0.10.3"
 requires "httpx >= 0.3.8"
 requires "chronicles >= 0.12.0"
+requires "gh:ire4ever1190/casserole >= 0.2.10"
 
 task ex, "Runs the example":
     selfExec "c -f -d:debug -r example"

--- a/src/mike/helpers/request.nim
+++ b/src/mike/helpers/request.nim
@@ -86,7 +86,7 @@ proc ip*(ctx: Context): IpAddress =
   ## Returns the first (leftmost) IP from forwarded headers,
   ## or falls back to the request's IP address if no forwarded header is present.
   let headers = ctx.headers
-  var ipVal
+  var ipVal: string
   block finding:
     # First try X-Forwarded-For which has some special parsing
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For
@@ -107,4 +107,11 @@ proc ip*(ctx: Context): IpAddress =
     ipVal = ctx.request.ip()
 
   # Now we parse it into an actual IP
-  return ipVal.parseAddress()
+  return ipVal.parseIpAddress()
+
+template fromRequest*(ctx: Context, _: string, result: out IpAddress) =
+  ## Context hook for getting [IpAddress](https://nim-lang.org/docs/net.html#IpAddress) of the client
+  ## connecting.
+  ##
+  ## See [ip]
+  result = ctx.ip

--- a/src/mike/helpers/request.nim
+++ b/src/mike/helpers/request.nim
@@ -5,6 +5,10 @@ import std/jsonutils
 import std/options
 import std/selectors
 import std/strformat
+import std/strutils
+import std/net
+
+import pkg/casserole
 
 {.used.}
 
@@ -41,12 +45,14 @@ proc headers*(ctx: Context): HttpHeaders {.raises: [].} =
   except KeyError, IOSelectorsException:
     newHttpHeaders()
 
-proc tryHeader*(ctx: Context, key: string): Option[string] =
+proc tryGet*(headers: HttpHeaders, key: string): Option[string] =
   ## Attempts to get a header, returns `None` if it doesn't exist
-  ctx.request.headers.flatMap do (headers: HttpHeaders) -> Option[string]:
-    if headers.hasKey(key):
-      return some string(headers[key])
+  if headers.hasKey(key):
+    return some string(headers[key])
 
+proc tryHeader*(ctx: Context, key: string): Option[string] =
+  ## See [tryGet]
+  ctx.headers.tryGet(key)
 
 proc getHeader*(ctx: Context, key: string): string =
   ## Gets a header from the request with `key`
@@ -66,5 +72,39 @@ proc getHeader*(ctx: Context, key, default: string): string =
     result = $ctx.headers.getOrDefault(key, @[default].HttpHeaderValues)
 
 proc hasHeader*(ctx: Context, key: string): bool {.raises: [].} =
-    ## Returns true if the request has header with `key`
-    result = ctx.headers.hasKey(key)
+  ## Returns true if the request has header with `key`
+  result = ctx.headers.hasKey(key)
+
+proc ip*(ctx: Context): IpAddress =
+  ## Gets the client IP address from the request.
+  ## Handles common forwarded headers:
+  ## - X-Forwarded-For
+  ## - X-Real-IP
+  ## - CF-Connecting-IP
+  ## - X-Client-IP
+  ##
+  ## Returns the first (leftmost) IP from forwarded headers,
+  ## or falls back to the request's IP address if no forwarded header is present.
+  let headers = ctx.headers
+  var ipVal
+  block finding:
+    # First try X-Forwarded-For which has some special parsing
+    # https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-Forwarded-For
+    if Some(forwardedFor) ?== headers.tryGet("X-Forwarded-For"):
+      # Return the first
+      for ip in forwardedFor.split(','):
+        ipVal = ip.strip()
+        break finding
+
+    # Next try basic headers that just contain a single IP
+    const basicHeaders = ["X-Real-IP", "CF-Connecting-IP", "X-Client-IP"]
+    for header in basicHeaders:
+      if Some(ip) ?== headers.tryGet(header):
+        ipVal = ip
+        break finding
+
+    # Just default to the direct IP of whats connecting to us
+    ipVal = ctx.request.ip()
+
+  # Now we parse it into an actual IP
+  return ipVal.parseAddress()

--- a/tests/testServer.nim
+++ b/tests/testServer.nim
@@ -10,7 +10,8 @@ import std/[
   unittest,
   httpclient,
   setutils,
-  options
+  options,
+  net
 ]
 
 
@@ -186,6 +187,9 @@ type
 "/data/something/other" -> beforeGet:
   discard
 
+"/ip" -> get(ip: IpAddress):
+  return $ip
+
 KeyError -> thrown:
   ctx.send("That key doesn't exist")
 
@@ -314,6 +318,8 @@ suite "Helpers":
   test "Range request header set":
     check head("/file?file=mike.nimble").headers["Accept-Ranges"] == "bytes"
 
+  test "Getting IP":
+    check get("/ip").body == "127.0.0.1"
 
 suite "Forms":
   test "URL encoded form GET":


### PR DESCRIPTION
Implements #71 

Function to get the IP of the client connecting, handles different headers that proxies add to carry the client IP through.
Also used this as an excuse to pull casserole into the project =P